### PR TITLE
Fix for React hooks

### DIFF
--- a/src/NavigationListener.jsx
+++ b/src/NavigationListener.jsx
@@ -62,12 +62,11 @@ class NavigationListener extends React.Component {
   }
 
   render () {
-    return this.props.story()
+    return <>{this.props.children}</>
   }
 }
 
 NavigationListener.propTypes = {
-  story: PropTypes.func.isRequired,
   router: routerShape.isRequired
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ const storyRouterDecorator = (routes = [{}], initialLocation = '') => {
           path: rootPath,
           Component: NavigationListener,
           render: ({ Component, props }) => (
-            <Component {...props} story={story} />
+            <Component {...props}>{story()}</Component>
           ),
           children: routes.map(normaliseRouteChildren)
         }


### PR DESCRIPTION
This fixes an error when using React hooks in stories. Using hooks would give:
```
Uncaught Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
```